### PR TITLE
chore: update publish workflow to set version number

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -33,6 +33,6 @@ jobs:
       run: mvn -Drevision=${{ steps.vars.outputs.tag }} -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn deploy -Drevision=${{ steps.vars.outputs.tag }} -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,8 +22,15 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+    - name: Get version tag
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+    - name: Echo version
+      run: echo ${{ steps.vars.outputs.tag }}
+
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -Drevision=${{ steps.vars.outputs.tag }} -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,12 @@
 	</parent>
 	<groupId>aaap.ch.harvest-forecast-client</groupId>
 	<artifactId>harvest-forecast-client</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>harvest-forecast-client</name>
 	<description>Client for Harvest Forecast</description>
 
 	<properties>
+		<revision>1.0.0-SNAPSHOT</revision>
 		<java.version>11</java.version>
 		<swagger-annotations-version>1.6.2</swagger-annotations-version>
 		<google-code-findbugs-version>3.0.2</google-code-findbugs-version>


### PR DESCRIPTION
This PR addresses ADM-705. It sets the version number of the published package so that every package is not versioned `0.0.1-SNAPSHOT` liek they currently are.

The version is set with the `-Drevision` flag of the `mvn publish` command. This is preset in the `pom.xml` so it doesn't need to be set everytime (for testing locally). In the workflow, the tag is extracted from the Git Refs, saved, and accessed with `${{ steps.vars.outputs.tag }}`.